### PR TITLE
feat: update kimi-k2 model configuration

### DIFF
--- a/models/llm/kimi-k2.yaml
+++ b/models/llm/kimi-k2.yaml
@@ -31,8 +31,3 @@ parameter_rules:
     min: 1
     max: 16384
     default: 16384
-pricing:
-  input: "4"
-  output: "16"
-  unit: "0.000001"
-  currency: RMB


### PR DESCRIPTION
- Add tool-call capabilities (tool-call, multi-tool-call, stream-tool-call)
- Adjust context size from 131072 to 128000 tokens
- Remove top_k default value and presence_penalty parameter
- Add max_tokens parameter with range 1-16384, default 16384