### PR TITLE
fix: Standardize naming conventions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,8 +19,8 @@ jobs:
             keep_tools: false
           - type: "kodo"
             name: "qiniu-tools"
-            filename: "qiniu-storage"
-            label_en: "Qiniu Storage"
+            filename: "qiniu-tools"
+            label_en: "Qiniu Tools"
             label_zh: "七牛云存储"
             keep_models: false
             keep_tools: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,9 +18,9 @@ jobs:
             keep_models: true
             keep_tools: false
           - type: "kodo"
-            name: "qiniu-tools"
-            filename: "qiniu-tools"
-            label_en: "Qiniu Tools"
+            name: "qiniu-storage"
+            filename: "qiniu-storage"
+            label_en: "Qiniu Storage"
             label_zh: "七牛云存储"
             keep_models: false
             keep_tools: true

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -1,4 +1,4 @@
-name: qiniu
+name: qiniu-full
 author: qiniu
 icon: icon_s_en.svg
 created_at: '2025-07-31T00:13:50.29298939-04:00'


### PR DESCRIPTION
- Update tools plugin filename from 'qiniu-storage' to 'qiniu-tools'
- Update tools plugin label from 'Qiniu Storage' to 'Qiniu Tools'
- Change main plugin name from 'qiniu' to 'qiniu-full' for clarity